### PR TITLE
Fix build recipes & rosdep definition

### DIFF
--- a/SC-PGO/CMakeLists.txt
+++ b/SC-PGO/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PCL REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Ceres REQUIRED)
+find_package(Boost REQUIRED COMPONENTS timer)
 
 find_package(OpenMP REQUIRED)
 find_package(GTSAM REQUIRED QUIET)

--- a/SC-PGO/package.xml
+++ b/SC-PGO/package.xml
@@ -28,6 +28,7 @@
   <build_depend>tf_conversions</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>ad_localization_msgs</build_depend>
+  <build_depend>cv_bridge</build_depend>
   
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>


### PR DESCRIPTION
1. In SC-PGO/package.xml, cv_bridge is used. This PR adds libopencv-dev to package.xml so that rosdep can install all the dependencies comprehensively.
2. When trying to compile the package, the linker's result will read
```
/usr/bin/ld: cannot find -lBoost::timer
```
This PR solves this problem by adding some line as per https://blog.csdn.net/qq_40113966/article/details/121765050 .